### PR TITLE
Remove use of namespace, keep it inline

### DIFF
--- a/src/Codeception/Module/Asserts.php
+++ b/src/Codeception/Module/Asserts.php
@@ -3,8 +3,6 @@
 namespace Codeception\Module;
 
 use Codeception\Lib\Notification;
-use Exception;
-use Throwable;
 
 /**
  * Special module for using asserts in your tests.
@@ -35,7 +33,7 @@ class Asserts extends AbstractAsserts
      * ```
      *
      * @deprecated Use expectThrowable() instead
-     * @param Exception|string $exception
+     * @param \Exception|string $exception
      * @param callable $callback
      */
     public function expectException($exception, $callback)
@@ -67,7 +65,7 @@ class Asserts extends AbstractAsserts
      * });
      * ```
      *
-     * @param Throwable|string $throwable
+     * @param \Throwable|string $throwable
      * @param callable $callback
      */
     public function expectThrowable($throwable, $callback)
@@ -84,10 +82,10 @@ class Asserts extends AbstractAsserts
 
         try {
             $callback();
-        } catch (Exception $t) {
+        } catch (\Exception $t) {
             $this->checkThrowable($t, $class, $msg, $code);
             return;
-        } catch (Throwable $t) {
+        } catch (\Throwable $t) {
             $this->checkThrowable($t, $class, $msg, $code);
             return;
         }
@@ -99,7 +97,7 @@ class Asserts extends AbstractAsserts
      * Check if the given throwable matches the expected data,
      * fail (throws an exception) if it does not.
      *
-     * @param Throwable $throwable
+     * @param \Throwable $throwable
      * @param string $expectedClass
      * @param string $expectedMsg
      * @param int $expectedCode


### PR DESCRIPTION
Hello! :-)

I noticed a change in this module recently that caused our static analyse to return errors as the file generated by Codeception is no longer valid. 

In this PR (https://github.com/Codeception/module-asserts/pull/7/files#diff-b3d3622a11b4688b45ee6999ce435bc0L178) a change was introduced that included the `Throwable` and `Exception` class via use instead of having it in the doc block as `\Throwable` and `\Exception`. Which is fine as the tests still run but when the support files are generated the use statements aren't copied causing the generated files to contain errors in the doc blocks (which continue into our tests, which are analysed for these sort of things). 

This PR reverts the change of using the namespaces. The tests still work but it looks wrong to have a generated file that isn't correct. Let me know if you need more information or if there's an alternative solution! 

Related screenshots from generated file:

![Skjermbilde 2020-08-31 kl  08 57 49](https://user-images.githubusercontent.com/7047894/91692362-8c876b80-eb69-11ea-9590-9c132ff024c2.png)
This is part of the `_generated/IntegrationTesterActions`. Marked in yellow, `Throwable` as undefined class. 

![Skjermbilde 2020-08-31 kl  09 10 26](https://user-images.githubusercontent.com/7047894/91692547-d4a68e00-eb69-11ea-8a47-c55f863e53ca.png)
This is what it used to be, does not contain the undefined class.


