### PR TITLE
Replace Codeception\Util\Stub with Codeception\Stub in tests

### DIFF
--- a/tests/unit/Codeception/Module/AssertsTest.php
+++ b/tests/unit/Codeception/Module/AssertsTest.php
@@ -5,7 +5,7 @@ namespace unit\Codeception\Module;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Module\Asserts;
 use Codeception\PHPUnit\TestCase;
-use Codeception\Util\Stub;
+use Codeception\Stub;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
 use RuntimeException;


### PR DESCRIPTION
Because Codeception\Util\Stub will be removed from Codeception 5.0