### PR TITLE
Code standards updated to PHP 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,35 @@
 {
-    "name":"codeception/module-asserts",
-    "description":"Codeception module containing various assertions",
-    "keywords":["codeception", "asserts", "assertions"],
-    "homepage":"https://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
+    "name": "codeception/module-asserts",
+    "description": "Codeception module containing various assertions",
+    "keywords": [ "codeception", "asserts", "assertions" ],
+    "homepage": "https://codeception.com/",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
         {
-            "name":"Michael Bodnarchuk"
+            "name": "Michael Bodnarchuk"
         },
         {
-            "name":"Gintautas Miselis"
+            "name": "Gintautas Miselis"
         },
         {
-            "name":"Gustavo Nieves",
+            "name": "Gustavo Nieves",
             "homepage": "https://medium.com/@ganieves"
         }
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": ">=5.6.0 <9.0",
+        "php": "^7.1 || ^8.0",
         "codeception/lib-asserts": "^1.13.1",
         "codeception/codeception": "*@dev"
     },
     "conflict": {
         "codeception/codeception": "<4.0"
     },
-    "autoload":{
-        "classmap": ["src/"]
+    "autoload": {
+        "classmap": [
+            "src/"
+        ]
     },
     "config": {
         "classmap-authoritative": true

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@
 
 A Codeception module containing various assertions.
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Module/AbstractAsserts.php
+++ b/src/Codeception/Module/AbstractAsserts.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Module;
 
-use Codeception\Module as CodeceptionModule;
-use Codeception\Util\Shared\Asserts as SharedAsserts;
+use Codeception\Module;
+use Codeception\Util\Shared\Asserts;
 
-abstract class AbstractAsserts extends CodeceptionModule
+abstract class AbstractAsserts extends Module
 {
-    use SharedAsserts {
+    use Asserts {
         assertArrayHasKey as public;
         assertArrayNotHasKey as public;
         assertClassHasAttribute as public;

--- a/src/Codeception/Module/Asserts.php
+++ b/src/Codeception/Module/Asserts.php
@@ -1,47 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Module;
 
-use Codeception\Lib\Notification;
+use Throwable;
 
 /**
  * Special module for using asserts in your tests.
  */
 class Asserts extends AbstractAsserts
 {
-    /**
-     * Handles and checks exception called inside callback function.
-     * Either exception class name or exception instance should be provided.
-     *
-     * ```php
-     * <?php
-     * $I->expectException(MyException::class, function() {
-     *     $this->doSomethingBad();
-     * });
-     *
-     * $I->expectException(new MyException(), function() {
-     *     $this->doSomethingBad();
-     * });
-     * ```
-     * If you want to check message or exception code, you can pass them with exception instance:
-     * ```php
-     * <?php
-     * // will check that exception MyException is thrown with "Don't do bad things" message
-     * $I->expectException(new MyException("Don't do bad things"), function() {
-     *     $this->doSomethingBad();
-     * });
-     * ```
-     *
-     * @deprecated Use expectThrowable() instead
-     * @param \Exception|string $exception
-     * @param callable $callback
-     */
-    public function expectException($exception, $callback)
-    {
-        Notification::deprecate('Use expectThrowable() instead');
-        $this->expectThrowable($exception, $callback);
-    }
-
     /**
      * Handles and checks throwables (Exceptions/Errors) called inside the callback function.
      * Either throwable class name or throwable instance should be provided.
@@ -65,10 +34,9 @@ class Asserts extends AbstractAsserts
      * });
      * ```
      *
-     * @param \Throwable|string $throwable
-     * @param callable $callback
+     * @param Throwable|string $throwable
      */
-    public function expectThrowable($throwable, $callback)
+    public function expectThrowable($throwable, callable $callback): void
     {
         if (is_object($throwable)) {
             $class = get_class($throwable);
@@ -82,45 +50,42 @@ class Asserts extends AbstractAsserts
 
         try {
             $callback();
-        } catch (\Exception $t) {
-            $this->checkThrowable($t, $class, $msg, $code);
-            return;
-        } catch (\Throwable $t) {
+        } catch (Throwable $t) {
             $this->checkThrowable($t, $class, $msg, $code);
             return;
         }
 
-        $this->fail("Expected throwable of class '$class' to be thrown, but nothing was caught");
+        $this->fail("Expected throwable of class '{$class}' to be thrown, but nothing was caught");
     }
 
     /**
      * Check if the given throwable matches the expected data,
      * fail (throws an exception) if it does not.
-     *
-     * @param \Throwable $throwable
-     * @param string $expectedClass
-     * @param string $expectedMsg
-     * @param int $expectedCode
      */
-    protected function checkThrowable($throwable, $expectedClass, $expectedMsg, $expectedCode)
+    protected function checkThrowable(Throwable $throwable, string $expectedClass, ?string $expectedMsg, ?int $expectedCode): void
     {
         if (!($throwable instanceof $expectedClass)) {
             $this->fail(sprintf(
-                "Exception of class '$expectedClass' expected to be thrown, but class '%s' was caught",
+                "Exception of class '%s' expected to be thrown, but class '%s' was caught",
+                $expectedClass,
                 get_class($throwable)
             ));
         }
 
         if (null !== $expectedMsg && $throwable->getMessage() !== $expectedMsg) {
             $this->fail(sprintf(
-                "Exception of class '$expectedClass' expected to have message '$expectedMsg', but actual message was '%s'",
+                "Exception of class '%s' expected to have message '%s', but actual message was '%s'",
+                $expectedClass,
+                $expectedMsg,
                 $throwable->getMessage()
             ));
         }
 
         if (null !== $expectedCode && $throwable->getCode() !== $expectedCode) {
             $this->fail(sprintf(
-                "Exception of class '$expectedClass' expected to have code '$expectedCode', but actual code was '%s'",
+                "Exception of class '%s' expected to have code '%s', but actual code was '%s'",
+                $expectedClass,
+                $expectedCode,
                 $throwable->getCode()
             ));
         }

--- a/tests/unit/Codeception/Module/AssertsTest.php
+++ b/tests/unit/Codeception/Module/AssertsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace unit\Codeception\Module;
 
 use Codeception\Lib\ModuleContainer;
@@ -11,7 +13,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use RuntimeException;
 use stdClass;
 
-class AssertsTest extends TestCase
+final class AssertsTest extends TestCase
 {
     /** @var Asserts */
     protected $module;


### PR DESCRIPTION
- The minimum version of PHP is now 7.1
- Added strict types
- Added return types
- Removed deprecated method `expectException`
- Removed unnecessary qualifiers