### PR TITLE
Bump lib-asserts dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.1",
         "codeception/codeception": "*@dev",
-        "codeception/lib-asserts": "^2.0"
+        "codeception/lib-asserts": "^2.2"
     },
     "conflict": {
         "codeception/codeception": "<5.0"


### PR DESCRIPTION
`codeception/lib-asserts:2.2` contains various compatibility fixes for newer PHPUnit versions.

The tests added in https://github.com/Codeception/module-asserts/pull/29 only work with these fixes.

This was discovered in https://github.com/Codeception/module-asserts/pull/29#issuecomment-2828563411