### PR TITLE
chore: allow installation of lib-asserts v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.2",
         "codeception/codeception": "*@dev",
-        "codeception/lib-asserts": "^2.2"
+        "codeception/lib-asserts": "^2.2 | ^3.0.1"
     },
     "conflict": {
         "codeception/codeception": "<5.0"


### PR DESCRIPTION
`codeception/lib-asserts` is a direct dependency of `codeception/codeception` which itself is a direct dependency of `codeception/module-asserts`.

I tested my changes locally by using a dev version of codeception which allows lib-asserts v3 and the CI was still green.

I'm going to prepare a PR which allows lib-asserts v3 in `codeception/codeception` as well.